### PR TITLE
increase Mono.Zip method

### DIFF
--- a/docs/mono/zip.md
+++ b/docs/mono/zip.md
@@ -1,0 +1,35 @@
+### Zip
+Use `Zip` to wrap an existing element.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/jjeffcaii/reactor-go"
+	"github.com/jjeffcaii/reactor-go/mono"
+	"github.com/jjeffcaii/reactor-go/scheduler"
+	"testing"
+)
+
+func TestZipMono(t *testing.T) {
+	mono.Zip(mono.JustOneshot(1).Map(func(any reactor.Any) (reactor.Any, error) {
+		return any.(int)+1,nil
+	}).SubscribeOn(scheduler.Parallel()), mono.JustOneshot(3).Map(func(any reactor.Any) (reactor.Any, error) {
+		return any.(int)+1,nil
+	}).SubscribeOn(scheduler.Parallel())).Map(func(any reactor.Any) (reactor.Any, error) {
+		var a = any.(*mono.Items)
+		fmt.Println("-----",a.It[1],a.It[0])
+		return any,nil
+	}).Subscribe(context.Background())
+	mono.Zip(mono.Error(fmt.Errorf("ddddddddd")),mono.Empty()).Map(func(any reactor.Any) (reactor.Any, error) {
+		var a = any.(*mono.Items)
+		fmt.Println("-----",a.It[1],a.It[0])
+		return any,nil
+	}).DoOnError(func(e error) {
+		fmt.Println("+++++")
+	}).Subscribe(context.Background())
+}
+
+```

--- a/mono/mono_zip.go
+++ b/mono/mono_zip.go
@@ -1,0 +1,139 @@
+package mono
+
+import (
+	"context"
+	"fmt"
+	"github.com/jjeffcaii/reactor-go"
+	"github.com/jjeffcaii/reactor-go/internal"
+	"sync"
+	"sync/atomic"
+)
+
+type Item struct {
+	V Any
+	Err error
+}
+type Items struct {
+	It []*Item
+}
+
+type monoZip struct {
+	value []Mono
+}
+
+type zipSubscription struct {
+	actual reactor.Subscriber
+	zVal   *monoZip
+	zCtx   context.Context
+	n      int32
+}
+var _zipSubscriptionPool = sync.Pool{
+	New: func() interface{} {
+		return new(zipSubscription)
+	},
+}
+
+func borrowZipSubscription() *zipSubscription {
+	return _zipSubscriptionPool.Get().(*zipSubscription)
+}
+
+func returnZipSubscription(s *zipSubscription) {
+	if s == nil {
+		return
+	}
+	s.actual = nil
+	atomic.StoreInt32(&s.n, 0)
+	_justSubscriptionPool.Put(s)
+}
+
+func newMonoZip(i ...Mono) *monoZip {
+	return &monoZip{
+		value: i,
+	}
+}
+
+func (z *zipSubscription) Request(n int) {
+	if z == nil || z.actual == nil  {
+		return
+	}
+	if n < 1 {
+		returnZipSubscription(z)
+		panic(reactor.ErrNegativeRequest)
+	}
+	if !atomic.CompareAndSwapInt32(&z.n, 0, statComplete) {
+		return
+	}
+	defer returnZipSubscription(z)
+	if z.zVal.value == nil {
+		z.actual.OnComplete()
+		return
+	}
+	defer func() {
+		if err := internal.TryRecoverError(recover()); err != nil {
+			z.actual.OnError(err)
+		} else {
+			z.actual.OnComplete()
+		}
+	}()
+	var i,e = z.combinedMonos(z.zVal.value)
+	if e != nil {
+		z.actual.OnComplete()
+	}else{
+		//fmt.Println("combinedMonos",i)
+		z.actual.OnNext(i)
+	}
+}
+func (z *zipSubscription) combinedMonos( m []Mono ) (*Items,error) {
+	if len(m) < 1 {
+		return nil,fmt.Errorf("Failed to compare combined. Mono is empty or less than 1\n\n")
+	}
+	var (
+		wg sync.WaitGroup
+		res = make([]*Item,0)
+	)
+	wg.Add(len(m))
+	for _,sub := range m {
+		var done int32 = 0
+		sub.Subscribe(z.zCtx,reactor.OnNext(func(r reactor.Any) error {
+			if atomic.CompareAndSwapInt32(&done,0,1){
+				res = append(res,&Item{Err: nil,V: r})
+			}
+			return nil
+		}),reactor.OnError(func(e error) {
+			res = append(res,&Item{Err: e,V: nil})
+			wg.Done()
+		}),reactor.OnComplete(func() {
+			if atomic.CompareAndSwapInt32(&done,0,1){
+				res = append(res,&Item{Err: nil,V: nil})
+			}else{
+				atomic.CompareAndSwapInt32(&done,1,0)
+			}
+			//res = append(res,&Item{Err: nil,V: nil})
+			wg.Done()
+		}))
+	}
+	wg.Wait()
+	return &Items{It:res},nil
+}
+func (z *zipSubscription) Cancel() {
+	if z == nil  || z.actual == nil {
+		return
+	}
+	atomic.CompareAndSwapInt32(&z.n, 0, statCancel)
+}
+
+func (m *monoZip) SubscribeWith(ctx context.Context, sub reactor.Subscriber) {
+	select {
+	case <-ctx.Done():
+		sub.OnError(reactor.ErrSubscribeCancelled)
+	default:
+		su := borrowZipSubscription()
+		su.actual = sub
+		su.zVal = m
+		su.zCtx = ctx
+		sub.OnSubscribe(ctx, su)
+	}
+}
+
+
+

--- a/mono/mono_zip_test.go
+++ b/mono/mono_zip_test.go
@@ -1,0 +1,34 @@
+package mono_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/jjeffcaii/reactor-go"
+	"github.com/jjeffcaii/reactor-go/mono"
+	"github.com/jjeffcaii/reactor-go/scheduler"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestZipMono(t *testing.T) {
+	mono.Zip(mono.JustOneshot(1).Map(func(any reactor.Any) (reactor.Any, error) {
+		return any.(int)+1,nil
+	}).SubscribeOn(scheduler.Parallel()), mono.JustOneshot(3).Map(func(any reactor.Any) (reactor.Any, error) {
+		return any.(int)+1,nil
+	}).SubscribeOn(scheduler.Parallel())).Map(func(any reactor.Any) (reactor.Any, error) {
+		var a = any.(*mono.Items)
+		t.Log("-----",a.It[1],a.It[0])
+		assert.NoError(t, a.It[1].Err, "should not return error")
+		assert.NoError(t, a.It[0].Err, "should not return error")
+		return any,nil
+	}).Subscribe(context.Background())
+	var r,e = mono.Zip(mono.Error(fmt.Errorf("ddddddddd")),mono.Empty()).Map(func(any reactor.Any) (reactor.Any, error) {
+		var a = any.(*mono.Items)
+		t.Log("-----",a.It[1],a.It[0])
+		return any,nil
+	}).DoOnError(func(e error) {
+		t.Log("DoOnError")
+	}).Block(context.Background())
+	t.Log("mono.zip.block:",r)
+	assert.NoError(t, e, "should not return error")
+}

--- a/mono/utils.go
+++ b/mono/utils.go
@@ -34,6 +34,9 @@ func Just(v Any) Mono {
 	return wrap(newMonoJust(v))
 }
 
+func Zip(m ...Mono) Mono {
+	return wrap(newMonoZip(m...))
+}
 func JustOneshot(v Any) Mono {
 	if v == nil {
 		panic(_errJustNilValue)


### PR DESCRIPTION
increase Mono.Zip Method, the function body is executed sequentially mono.subscribe 。 If mono belt scheduler.Parallel () is executed in parallel, and everything is controlled by the outer mono

