### PR TITLE
Compiler fix for Go 1.18

### DIFF
--- a/flux/types.go
+++ b/flux/types.go
@@ -19,7 +19,7 @@ const (
 )
 
 type Any = reactor.Any
-type FnSwitchOnFirst = func(s Signal, f Flux) Flux
+type FnSwitchOnFirst func(s Signal, f Flux) Flux
 
 type Flux interface {
 	reactor.Publisher


### PR DESCRIPTION
When compiling with Go 1.18, this error occurs:

```
# github.com/jjeffcaii/reactor-go/flux
../../../../pkg/mod/github.com/jjeffcaii/reactor-go@v0.5.2/flux/types.go:37:16: invalid use of type alias FnSwitchOnFirst in recursive type (see issue #50729)
```

This PR makes a small change for the code o compile again. If merged, please create a release.